### PR TITLE
Fixed Blade facade being called from local namespace

### DIFF
--- a/src/Flynsarmy/DbBladeCompiler/DbBladeCompiler.php
+++ b/src/Flynsarmy/DbBladeCompiler/DbBladeCompiler.php
@@ -9,15 +9,18 @@ class DbBladeCompiler extends BladeCompiler implements CompilerInterface
     /** @var \Illuminate\Config\Repository */
     protected $config;
 
-    public function __construct($filesystem, $cache_path, $config)
-        {
+    public function __construct($filesystem, $cache_path, $config, $app)
+    {
+    	// Get Current Blade Instance
+    	$blade = $app->make('blade.compiler');
+
         parent::__construct($filesystem, $cache_path);
-        $this->rawTags     = Blade::getRawTags();
-        $this->contentTags = Blade::getContentTags();
-        $this->escapedTags = Blade::getEscapedContentTags();
-        $this->extensions  = Blade::getExtensions();
+        $this->rawTags     = $blade->getRawTags();
+        $this->contentTags = $blade->getContentTags();
+        $this->escapedTags = $blade->getEscapedContentTags();
+        $this->extensions  = $blade->getExtensions();
         $this->config      = $config;
-        }
+    }
 
 	/**
 	 * Compile the view at the given path.

--- a/src/Flynsarmy/DbBladeCompiler/DbBladeCompilerServiceProvider.php
+++ b/src/Flynsarmy/DbBladeCompiler/DbBladeCompilerServiceProvider.php
@@ -41,7 +41,7 @@ class DbBladeCompilerServiceProvider extends ServiceProvider {
         $cache_path = storage_path('app/db-blade-compiler/views');
 
         $db_view = new DbView($app['config']);
-        $compiler = new DbBladeCompiler($app['files'], $cache_path, $app['config']);
+        $compiler = new DbBladeCompiler($app['files'], $cache_path, $app['config'], $app);
         $db_view->setEngine(new CompilerEngine($compiler));
 
         return $db_view;


### PR DESCRIPTION
Removed the call to the Blade facade from the local namespace. This was causing an exception.

Also changed it to get the current BladeCompiler instance from the $app variable used in the provider not using a facade so if its removed as a facade in config it will still function.