### PR TITLE
Remove $this->app->share call

### DIFF
--- a/src/Flynsarmy/DbBladeCompiler/DbBladeCompilerServiceProvider.php
+++ b/src/Flynsarmy/DbBladeCompiler/DbBladeCompilerServiceProvider.php
@@ -36,10 +36,10 @@ class DbBladeCompilerServiceProvider extends ServiceProvider
     {
         $config_path = __DIR__ . '/../../../config/db-blade-compiler.php';
         $this->mergeConfigFrom($config_path, 'db-blade-compiler');
-
-        $this->app['dbview'] = $this->app->share(function ($app) {
-            return $app->make(DbView::class);
-        });
+        
+        $this->app->singleton(DbView::class);
+        
+        $this->app->alias(DbView::class, 'dbview');
 
         $this->app->bind(DbBladeCompiler::class, function($app) {
             $cache_path = storage_path('app/db-blade-compiler/views');


### PR DESCRIPTION
Share no longer exists in Laravel 5.4. This will bind the class to the container without breaking existing code.