### PR TITLE
Feature/laravel 5 4 compatibility blade compiler

### DIFF
--- a/src/Flynsarmy/DbBladeCompiler/DbBladeCompiler.php
+++ b/src/Flynsarmy/DbBladeCompiler/DbBladeCompiler.php
@@ -17,9 +17,9 @@ class DbBladeCompiler extends BladeCompiler implements CompilerInterface
         $blade = app('view')->getEngineResolver()->resolve('blade')->getCompiler();
 
         parent::__construct($filesystem, $cache_path);
-        $this->rawTags          = $blade->getRawTags();
-        $this->contentTags      = $blade->getContentTags();
-        $this->escapedTags      = $blade->getEscapedContentTags();
+        $this->rawTags          = $blade->rawTags;
+        $this->contentTags      = array_map('stripcslashes', $blade->contentTags);
+        $this->escapedTags      = array_map('stripcslashes', $blade->escapedTags);
         $this->extensions       = $blade->getExtensions();
         $this->customDirectives = $blade->getCustomDirectives();
         $this->config           = $config;

--- a/src/Flynsarmy/DbBladeCompiler/DbView.php
+++ b/src/Flynsarmy/DbBladeCompiler/DbView.php
@@ -74,7 +74,7 @@ class DbView extends \Illuminate\View\View implements ArrayAccess, Renderable
         // Once we have the contents of the view, we will flush the sections if we are
         // done rendering all views so that there is nothing left hanging over when
         // anothoer view is rendered in the future by the application developers.
-        View::flushStateIfDoneRendering();
+        ( str_contains( app()->version(), ['5.3','5.2', '5.1']) ? View::flushSectionsIfDoneRendering() : View::flushStateIfDoneRendering());
 
         return $response ?: $contents;
     }

--- a/src/Flynsarmy/DbBladeCompiler/DbView.php
+++ b/src/Flynsarmy/DbBladeCompiler/DbView.php
@@ -74,7 +74,7 @@ class DbView extends \Illuminate\View\View implements ArrayAccess, Renderable
         // Once we have the contents of the view, we will flush the sections if we are
         // done rendering all views so that there is nothing left hanging over when
         // anothoer view is rendered in the future by the application developers.
-        View::flushSectionsIfDoneRendering();
+        View::flushStateIfDoneRendering();
 
         return $response ?: $contents;
     }


### PR DESCRIPTION
This is my first open source contribution, so hopefully I'm doing this correctly (not quite sure here).

This adds more compatibility with L5.4, and (_hopefully_) fixes the `Call to undefined method Illuminate\View\Factory::flushSectionsIfDoneRendering()` [issue](https://github.com/Flynsarmy/laravel-db-blade-compiler/issues/28).

One change I made is in DbView class, line 77. Changed to check which version of Laravel is being used, and calls appropriate method based on the version.

The Second change I made was in DbBladeCompiler class, lines 20-22. It looks like in L5.4 the accessor methods were removed from the [BladeCompiler](https://github.com/laravel/framework/blob/5.4/src/Illuminate/View/Compilers/BladeCompiler.php), so I just grabbed the values straight from the protected attributes. The `contentTags`, and `escapedTags` in L5.3 were being called by [getTags(](https://github.com/laravel/framework/blob/5.3/src/Illuminate/View/Compilers/BladeCompiler.php)) method, which did an `array_map('stripcslashes')`. I just called that on the attributes.