### PR TITLE
dont set DbView alias in service provider

### DIFF
--- a/src/Flynsarmy/DbBladeCompiler/DbBladeCompilerServiceProvider.php
+++ b/src/Flynsarmy/DbBladeCompiler/DbBladeCompilerServiceProvider.php
@@ -47,9 +47,6 @@ class DbBladeCompilerServiceProvider extends ServiceProvider
             return new DbBladeCompiler($app['files'], $cache_path, $app['config']);
         });
 
-        $this->app->booting(function () {
-            $loader = \Illuminate\Foundation\AliasLoader::getInstance();            
-        });
     }
 
     /**

--- a/src/Flynsarmy/DbBladeCompiler/DbBladeCompilerServiceProvider.php
+++ b/src/Flynsarmy/DbBladeCompiler/DbBladeCompilerServiceProvider.php
@@ -48,8 +48,7 @@ class DbBladeCompilerServiceProvider extends ServiceProvider
         });
 
         $this->app->booting(function () {
-            $loader = \Illuminate\Foundation\AliasLoader::getInstance();
-            $loader->alias('DbView', DbView::class);
+            $loader = \Illuminate\Foundation\AliasLoader::getInstance();            
         });
     }
 


### PR DESCRIPTION
Was running into following error
```Non-static method Flynsarmy\DbBladeCompiler\DbView::make() should not be called statically```

Seems the advice of issue #30 + using dev-master instead of latest release fixes this