### PR TITLE
Update DbView.php

### DIFF
--- a/src/Flynsarmy/DbBladeCompiler/DbView.php
+++ b/src/Flynsarmy/DbBladeCompiler/DbView.php
@@ -74,7 +74,11 @@ class DbView extends \Illuminate\View\View implements ArrayAccess, Renderable
         // Once we have the contents of the view, we will flush the sections if we are
         // done rendering all views so that there is nothing left hanging over when
         // anothoer view is rendered in the future by the application developers.
-        ( str_contains( app()->version(), ['5.3','5.2', '5.1']) ? View::flushSectionsIfDoneRendering() : View::flushStateIfDoneRendering());
+        // Before flushing, check Laravel version for correct method use
+        if ( version_compare(app()->version(), '5.4.0') >= 0 ) 
+            View::flushStateIfDoneRendering();
+        else 
+            View::flushSectionsIfDoneRendering();
 
         return $response ?: $contents;
     }


### PR DESCRIPTION
Updates my previous pull request that checked Laravel version. It was failing because it was finding '5.2' string in the 5.5.2 Laravel version. This new PR makes use of PHP's built in version_compare function to compare versions rather than just doing a string compare. Anything L5.4 and up uses flushStateIfDoneRendering().